### PR TITLE
fix(pydantic-settings): Fix BaseSettings Import

### DIFF
--- a/{{cookiecutter.project_slug}}/requirements-common.txt
+++ b/{{cookiecutter.project_slug}}/requirements-common.txt
@@ -2,3 +2,4 @@ black
 pathway
 python-dotenv
 pydantic
+pydantic-settings

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/config.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/config.py
@@ -2,7 +2,7 @@ from functools import lru_cache
 from typing import Literal
 
 from dotenv import load_dotenv
-from pydantic import BaseSettings
+from pydantic_settings import BaseSettings
 
 ENV_FILE_PATH = "config/.env"
 


### PR DESCRIPTION
# Context
When installing Pydantic v2, [BaseSettings has moved to pydantic-settings](https://docs.pydantic.dev/2.0/migration/#basesettings-has-moved-to-pydantic-settings), causing an error.

# Issue
[[Bug]: Pydantic BaseSettings have moved to pydantic-settings](https://github.com/pathwaycom/cookiecutter-pathway/issues/1)
